### PR TITLE
Retune chip spawn curve for early levels

### DIFF
--- a/stealth_shooter_levels.html
+++ b/stealth_shooter_levels.html
@@ -336,15 +336,25 @@
     }
 
     function randInt(a,b){ return a + Math.floor(Math.random()*(b-a+1)); }
-    const LVL_CHIPS_MIN=4, LVL_CHIPS_RAMP=1, LVL_CHIPS_JITTER=2, LVL_CHIPS_CAP=18;
+    const LVL_CHIPS_START=2, LVL_CHIPS_TARGET=20, LVL_CHIPS_TARGET_LVL=10, LVL_CHIPS_LATE_RAMP=1;
+    const LVL_CHIPS_JITTER=2, LVL_CHIPS_CAP=26;
     const LVL_ENEMY_BASE=3, LVL_ENEMY_RAMP=1, LVL_ENEMY_JITTER=1;
     const DEPOSIT_SPAWN_LVL_STEP=3;
 
+    function levelProgress(level, target){
+      if(target<=1) return 1;
+      return clamp((level-1)/(target-1), 0, 1);
+    }
+
     function chipsForLevel(level){
-      const base = LVL_CHIPS_MIN + Math.floor((level-1)*LVL_CHIPS_RAMP);
-      const jitter = randInt(0, LVL_CHIPS_JITTER);
-      const scaled = Math.round((base + jitter) * Math.pow(densFactor, 0.5));
-      return Math.min(LVL_CHIPS_CAP * Math.max(1, Math.round(Math.pow(densFactor, 0.5))), Math.max(1, scaled));
+      const densScale = Math.pow(densFactor, 0.5);
+      const progress = levelProgress(level, LVL_CHIPS_TARGET_LVL);
+      const base = LVL_CHIPS_START + progress * (LVL_CHIPS_TARGET - LVL_CHIPS_START);
+      const lateRamp = Math.max(0, level - LVL_CHIPS_TARGET_LVL) * LVL_CHIPS_LATE_RAMP;
+      const jitter = randInt(0, Math.max(1, Math.round(LVL_CHIPS_JITTER * (0.5 + 0.5 * progress))));
+      const scaled = Math.round((base + lateRamp + jitter) * densScale);
+      const cap = LVL_CHIPS_CAP * Math.max(1, Math.round(densScale));
+      return Math.min(cap, Math.max(1, scaled));
     }
 
     function placeChips(n,walls,safe){


### PR DESCRIPTION
## Summary
- restore the chip spawn logic to focus on a gradual ramp from sparse early pickups to denser later stages
- scale chip counts from about two on level 1 toward twenty by level 10 while keeping late-game density increases modest

## Testing
- not run (HTML game)


------
https://chatgpt.com/codex/tasks/task_e_68daae33761c832ea8796885feb0bb25